### PR TITLE
fix: Rb delay dependency update

### DIFF
--- a/evrMrmApp/Db/Makefile
+++ b/evrMrmApp/Db/Makefile
@@ -6,6 +6,7 @@ include $(TOP)/configure/CONFIG
 USR_DBFLAGS += -I$(TOP)/mrmShared/Db
 
 DB += mrmevrout.db
+DB += mrmevroutdly.db
 DB += mrmevrbase.template
 DB += mrmevrdc.template
 DB += mrmevrbufrx.db

--- a/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
@@ -500,10 +500,20 @@ file "evrin.db"
 }
 
 # Obsolete: check inside mrmevrdlymodule.template for more info
+# Left for the backward compatibility - use mrmevroutdly.db instead
 file "mrmevrdlymodule.template"
 {pattern
 {SLOT, P, OBJ}
 {0, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
 {1, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+}
 
+file "mrmevroutdly.db"
+{pattern
+{ON, OBJ}
+# FP UNIV
+{"\$(P)OutFPUV0",  "$(EVR):FrontUnivOut0"}
+{"\$(P)OutFPUV1",  "$(EVR):FrontUnivOut1"}
+{"\$(P)OutFPUV2",  "$(EVR):FrontUnivOut2"}
+{"\$(P)OutFPUV3",  "$(EVR):FrontUnivOut3"}
 }

--- a/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
@@ -499,6 +499,7 @@ file "evrin.db"
 {"\$(P)BPIn7"   , "$(EVR):FPIn31", "BPIN7 (LVDS)"}
 }
 
+# Obsolete: check inside mrmevrdlymodule.template for more info
 file "mrmevrdlymodule.template"
 {pattern
 {SLOT, P, OBJ}

--- a/evrMrmApp/Db/mrmevrdlymodule.template
+++ b/evrMrmApp/Db/mrmevrdlymodule.template
@@ -1,3 +1,8 @@
+# Deprecated: mrmevrdlymodule.template
+# This template is obsolete and should not be used in new implementations.
+# It will be removed in future versions. Please use evrMrmApp/Db/mrmevrout.db $(ON)FineDelay-SP and $(ON)FineDelay-RB instead.
+# Date of obsolescence: [17/09/2024]
+
 # Delay Module control
 #
 # Macros:

--- a/evrMrmApp/Db/mrmevrout.db
+++ b/evrMrmApp/Db/mrmevrout.db
@@ -523,31 +523,3 @@ record(waveform, "$(ON)Label-I") {
   info(autosaveFields_pass1, "VAL")
   alias("$(ON)User-SP")
 }
-
-# Fine delay
-
-record(ao, "$(ON)FineDelay-SP") {
-  field( DESC, "Fine delay output")
-  field( DTYP, "Obj Prop double")
-  field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
-  field( EGU , "ns")
-  field( PINI, "YES")
-  field( VAL , "0")
-  field( HOPR, "8.686")
-  field( LOPR, "0")
-  field( DRVH, "10")
-  field( DRVL, "0")
-  field( PREC, "2")
-  field( FLNK, "$(ON)FineDelay-RB")
-  info( autosaveFields_pass0, "VAL")
-}
-
-record(ai, "$(ON)FineDelay-RB") {
-  field( DESC, "Fine delay")
-  field( DTYP, "Obj Prop double")
-  field( INP , "@OBJ=$(OBJ), PROP=Fine Delay")
-  field( HIHI, "8.687")
-  field( LOLO, "-0.001")
-  field( PREC, "2")
-  field( EGU,  "ns")
-}

--- a/evrMrmApp/Db/mrmevrout.db
+++ b/evrMrmApp/Db/mrmevrout.db
@@ -527,7 +527,7 @@ record(waveform, "$(ON)Label-I") {
 # Fine delay
 
 record(ao, "$(ON)FineDelay-SP") {
-  field( DESC, "First delay output")
+  field( DESC, "Fine delay output")
   field( DTYP, "Obj Prop double")
   field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
   field( EGU , "ns")
@@ -535,19 +535,19 @@ record(ao, "$(ON)FineDelay-SP") {
   field( VAL , "0")
   field( HOPR, "8.686")
   field( LOPR, "0")
-  field( PREC, 2)
+  field( DRVH, "10")
+  field( DRVL, "0")
+  field( PREC, "2")
   field( FLNK, "$(ON)FineDelay-RB")
   info( autosaveFields_pass0, "VAL")
 }
 
 record(ai, "$(ON)FineDelay-RB") {
-  field( DESC, "First delay readback")
+  field( DESC, "Fine delay")
   field( DTYP, "Obj Prop double")
   field( INP , "@OBJ=$(OBJ), PROP=Fine Delay")
   field( HIHI, "8.687")
   field( LOLO, "-0.001")
-  field( PREC, 2)
+  field( PREC, "2")
   field( EGU,  "ns")
 }
-
-

--- a/evrMrmApp/Db/mrmevroutdly.db
+++ b/evrMrmApp/Db/mrmevroutdly.db
@@ -1,0 +1,28 @@
+# Fine delay adapter for mrmevrout.db - outputs with the fine delay capability
+# This file depreciates the mrmevrdlymodule.template
+
+record(ao, "$(ON)FineDelay-SP") {
+  field( DESC, "Fine delay output")
+  field( DTYP, "Obj Prop double")
+  field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
+  field( EGU , "ns")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "8.686")
+  field( LOPR, "0")
+  field( DRVH, "10")
+  field( DRVL, "0")
+  field( PREC, "2")
+  field( FLNK, "$(ON)FineDelay-RB")
+  info( autosaveFields_pass0, "VAL")
+}
+
+record(ai, "$(ON)FineDelay-RB") {
+  field( DESC, "Fine delay")
+  field( DTYP, "Obj Prop double")
+  field( INP , "@OBJ=$(OBJ), PROP=Fine Delay")
+  field( HIHI, "8.687")
+  field( LOLO, "-0.001")
+  field( PREC, "2")
+  field( EGU,  "ns")
+}


### PR DESCRIPTION
@hongran , 
* I changed the DESC of the FineDelay records as your implementation does not distinguish: first or second, it is per output.
* I added the obsolescence notes to the "mrmevrdlymodule.template" and "evrMrmApp/Db/evr-mtca-300u.uv.substitutions" - your implementation covers that so those should not be used in the future.
* I created a new file "mrmevroutdly.db" to handle the new way of the record support. With that, it can be used just for the selected outputs (not all) - check evr-mtca-300u.uv.substitutions

If I am correct in my analysis then please let me know.

Extra question:
What is the model reference of the new fine-delay output modules for the TB?